### PR TITLE
Bugfix/issue 110 doc agent embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ uv.lock
 .hatch
 .tox
 !**/.env.example
+.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Also, make sure the npm token is not expired
 - Added cli option to skip dependencies installation when running a flow
 - Fixed importing and exporting flows for skipping dependencies installation
 - Fixed internal messages not showing in the vscode extension when WAAT is used
+- Fixed Doc Agent exports with non-OpenAI LLMs requiring OpenAI embeddings by default
 - Updated jupyter dependencies to 4.5.2
 - Minor UI related changes
 - Dependencies updates

--- a/tests/exporting/agent/extras/test_doc_agent_extras.py
+++ b/tests/exporting/agent/extras/test_doc_agent_extras.py
@@ -19,6 +19,7 @@ def test_export_doc_agent(tmp_path: Path) -> None:
         Temporary path for the output directory.
     """
     agent, tools, models = create_agent(1, "doc_agent")
+    agent.data.model_ids = [models[0].id]
     output_dir = tmp_path / "test_doc_agent_exporter"
     output_dir.mkdir(exist_ok=True)
     models_and_names = (models, {model.id: model.name for model in models})
@@ -36,6 +37,22 @@ def test_export_doc_agent(tmp_path: Path) -> None:
     assert result
     assert result.main_content
     assert "query_engine=" in result.main_content
+    assert any(
+        import_statement.statement
+        == (
+            "from llama_index.embeddings.huggingface "
+            "import HuggingFaceEmbedding"
+        )
+        for import_statement in result.imports
+    )
+    content = "\n".join(
+        item.content for item in result.positioned_content
+    )
+    assert "Settings.embed_model = HuggingFaceEmbedding(" in content
+    assert (
+        content.index("Settings.embed_model = HuggingFaceEmbedding(")
+        < content.index("VectorChromaQueryEngine(")
+    )
 
     exporter = create_agent_exporter(
         agent=agent,
@@ -52,3 +69,7 @@ def test_export_doc_agent(tmp_path: Path) -> None:
     assert result
     assert result.main_content
     assert "query_engine=" in result.main_content
+    content = "\n".join(
+        item.content for item in result.positioned_content
+    )
+    assert "Settings.embed_model = HuggingFaceEmbedding(" in content

--- a/waldiez/exporting/agent/extras/doc_agent_extras.py
+++ b/waldiez/exporting/agent/extras/doc_agent_extras.py
@@ -135,6 +135,39 @@ class DocAgentProcessor:
                 self.agent.data.get_collection_name(),
             )
 
+    def get_default_embedding_model_setup(self, before: str) -> str:
+        """Get default LlamaIndex embedding setup for vector query engines.
+
+        LlamaIndex falls back to OpenAIEmbedding when no embedding model is
+        configured. Use a local HuggingFace embedding by default so Doc Agents
+        can work with non-OpenAI LLMs.
+        """
+        if "Settings.embed_model" in before:
+            return before
+        self.extras.add_import(
+            ImportStatement(
+                statement="from llama_index.core import Settings",
+                position=ImportPosition.THIRD_PARTY,
+            )
+        )
+        self.extras.add_import(
+            ImportStatement(
+                statement=(
+                    "from llama_index.embeddings.huggingface "
+                    "import HuggingFaceEmbedding"
+                ),
+                position=ImportPosition.THIRD_PARTY,
+            )
+        )
+        setup = (
+            "Settings.embed_model = HuggingFaceEmbedding(\n"
+            '    model_name="sentence-transformers/all-MiniLM-L6-v2",\n'
+            ")"
+        )
+        if before.strip():
+            return f"{before.rstrip()}\n{setup}\n"
+        return f"{setup}\n"
+
     def get_in_memory_query_engine_extras(self) -> None:
         """Get the in-memory query engine extras."""
         # InMemoryQueryEngine(llm_config=llm_config)
@@ -185,6 +218,7 @@ class DocAgentProcessor:
             )
         )
         llm_arg, before = self.get_llm_arg()
+        before = self.get_default_embedding_model_setup(before)
         db_path = self.get_db_path()
         self.extras.before_agent = before + "\n"
         q_engine_init = (
@@ -228,6 +262,7 @@ class DocAgentProcessor:
         )
         db_path = self.get_db_path()
         llm_arg, before = self.get_llm_arg()
+        before = self.get_default_embedding_model_setup(before)
         self.extras.before_agent = before + "\n"
         q_engine_init = (
             f"{self.agent_name}_query_engine = "


### PR DESCRIPTION
Fixes #110

## Description of the Change

Doc Agent exports now configure a default non-OpenAI embedding model when no embedding model is already set.

Previously, Doc Agent flows using non-OpenAI LLMs such as Claude could still trigger LlamaIndex's default OpenAI embedding behavior, requiring `OPENAI_API_KEY` even when the flow only used an Anthropic model.

This change adds a default HuggingFace embedding setup for exported Doc Agent flows using `sentence-transformers/all-MiniLM-L6-v2`.

The export preserves existing explicit embedding configuration, including NIM/vector DB-specific setup, and only adds the default when `Settings.embed_model` has not already been configured.

Tests were updated to cover Doc Agent export with an Anthropic model and verify that the HuggingFace embedding setup is included before the query engine is created.

## Checklist

- [x] PR only contains one change
- [x] tests added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated
